### PR TITLE
Add macOS instructions for installing Glide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ run packaging/install-vips.sh
 
 #### GO dependencies
 
+Only on macOS, you have to manually install _Glide_ using _Brew_.
+```bash
+brew install glide
+```
+
+Then, for all.
 ```
 ./packaging/build.sh
 go get github.com/Masterminds/glide


### PR DESCRIPTION
The instructions as they are are not enough. On _macOS_, we apparently need to `brew install` it.