### PR TITLE
#58 configure Travis for automatic version increment and GIT-version-tag 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ tag:
 	git tag $(VERSION)
 
 push-tags:
-	git push --tags https://$(GITHUB_AUTH)@github.com/zalando/skipper
+	git push --tags https://$(GITHUB_AUTH)@github.com/zalando-stups/skrop
 
 release-major:
 	make VERSION=$(NEXT_MAJOR) tag push-tags


### PR DESCRIPTION
Push tags to the RIGHT GitHub repository