### PR TITLE
58 auto versions with travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 .DEFAULT_GOAL := all
 
-version ?= latest
 routes_file ?= ./eskip/sample.eskip
 docker_tag ?= zalando-stups/skrop
+
+CURRENT_VERSION    = $(shell git describe --tags --always --dirty)
+VERSION           ?= $(CURRENT_VERSION)
+NEXT_MAJOR         = $(shell go run packaging/version/version.go major $(CURRENT_VERSION))
+NEXT_MINOR         = $(shell go run packaging/version/version.go minor $(CURRENT_VERSION))
+NEXT_PATCH         = $(shell go run packaging/version/version.go patch $(CURRENT_VERSION))
+COMMIT_HASH        = $(shell git rev-parse --short HEAD)
 
 glide:
 	glide install
@@ -11,7 +17,7 @@ build: glide
 	go build ./cmd/skrop
 
 docker:
-	./packaging/build.sh $(version) $(routes_file) $(docker_tag)
+	./packaging/build.sh $(VERSION) $(routes_file) $(docker_tag)
 
 docker-run:
 	docker run --rm -v "$$(pwd)"/images:/images -p 9090:9090 zalando-stups/skrop -verbose

--- a/packaging/version/version.go
+++ b/packaging/version/version.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+)
+
+const format = "v%d.%d.%d"
+
+const (
+	cmdMajor = "major"
+	cmdMinor = "minor"
+	cmdPatch = "patch"
+)
+
+var invalidCommand = errors.New("invalid command")
+
+func usage() string {
+	return `version <major|minor|patch> <currentVersion>`
+}
+
+func command() (string, string, error) {
+	if len(os.Args) != 3 {
+		return "", "", invalidCommand
+	}
+
+	switch os.Args[1] {
+	case cmdMajor, cmdMinor, cmdPatch:
+		return os.Args[1], os.Args[2], nil
+	default:
+		return "", "", invalidCommand
+	}
+}
+
+func inc(cmd string, major, minor, patch *int) {
+	switch cmd {
+	case cmdMajor:
+		*major++
+		*minor = 0
+		*patch = 0
+	case cmdMinor:
+		*minor++
+		*patch = 0
+	case cmdPatch:
+		*patch++
+	}
+}
+
+func main() {
+	cmd, current, err := command()
+	if err != nil {
+		log.Fatalln(usage())
+	}
+
+	var major, minor, patch int
+	_, err = fmt.Sscanf(current, format, &major, &minor, &patch)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	inc(cmd, &major, &minor, &patch)
+	fmt.Printf(format, major, minor, patch)
+}


### PR DESCRIPTION
- added values at the top of the `Makefile`, that are needed for the versioning
- added the `version.go` script, needed to determine the values added in the `Makefile`