### PR TITLE
#58 switching to a more manual way, but without pitfalls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ docker_tag ?= zalando-stups/skrop
 
 CURRENT_VERSION    = $(shell git describe --tags --always --dirty)
 VERSION           ?= $(CURRENT_VERSION)
-NEXT_MAJOR         = $(shell go run packaging/version/version.go major $(CURRENT_VERSION))
-NEXT_MINOR         = $(shell go run packaging/version/version.go minor $(CURRENT_VERSION))
 NEXT_PATCH         = $(shell go run packaging/version/version.go patch $(CURRENT_VERSION))
 COMMIT_HASH        = $(shell git rev-parse --short HEAD)
 
@@ -43,36 +41,23 @@ tag:
 push-tags:
 	git push --tags https://$(GITHUB_AUTH)@github.com/zalando-stups/skrop
 
-release-major:
-	echo Incrementing major version
-	make VERSION=$(NEXT_MAJOR) tag push-tags
-
-release-minor:
-	echo Incrementing minor version
-	make VERSION=$(NEXT_MINOR) tag push-tags
-
 release-patch:
-	echo Incrementing patch version
+	echo "Incrementing patch version"
 	make VERSION=$(NEXT_PATCH) tag push-tags
 
 ci-user:
 	git config --global user.email "builds@travis-ci.com"
 	git config --global user.name "Travis CI"
 
-ci-release-major: ci-user init-deps release-major
-ci-release-minor: ci-user init-deps release-minor
 ci-release-patch: ci-user init-deps release-patch
 
 ci-test:
 	./.travis/test.sh
 
 ci-trigger: ci-test
-ifeq ($(TRAVIS_BRANCH)_$(TRAVIS_PULL_REQUEST)_$(findstring major-release,$(TRAVIS_COMMIT_MESSAGE)), master_false_major-release)
-	make ci-release-major
-else ifeq ($(TRAVIS_BRANCH)_$(TRAVIS_PULL_REQUEST)_$(findstring minor-release,$(TRAVIS_COMMIT_MESSAGE)), master_false_minor-release)
-	make ci-release-minor
-else ifeq ($(TRAVIS_BRANCH)_$(TRAVIS_PULL_REQUEST), master_false)
+ifeq ($(TRAVIS_BRANCH)_$(TRAVIS_PULL_REQUEST), master_false)
+	echo "Merge to 'master'. Tagging patch version up."
 	make ci-release-patch
 else
-	echo Not a merge to 'master'. Not versionning this merge.
+	echo "Not a merge to 'master'. Not versionning this merge."
 endif

--- a/README.md
+++ b/README.md
@@ -168,17 +168,43 @@ env:
 - secure: "someBASE64value"
 ```
 
-### Versioning
+## Versioning
 
-This project uses [semantic versioning](https://semver.org/). The version is bumped up automatically at
-every merge to master (by [_Travis CI_](/.travis.yml)).
+This project uses [semantic versioning](https://semver.org/).
 
-To control which part of the version is bumped up, the commit message of the merge commit (including the first line
-of the commit message of all commits it consist of) has to include a special part.
-- `major-release`: the first digit (the major version) will be incremented. Example: from `3.23.291` to `4.0.0`.
-- `minor-release`: the second digit (the minor version) will be incremented. Example: from `3.23.291` to `3.24.0`.
-- anything else not including one of the text above will result in the third digit (the patch version) to be incremented.
-  Example: `3.23.291` to `3.23.292`.
+The patch-version (3rd digit) is bumped up automatically at every merge to master (by [_Travis CI_](/.travis.yml)).
+
+### Increment the patch version
+This is done automatically by _Travis CI_. Nothing special to do here. Example: merging when latest tag is `v3.23.291`
+will automaticall tag a version `v3.23.292`.
+
+### Increment the minor version
+Since _Travis CI_ only automatically increases the patch-version, we need to manually pre-tag with the new version we
+want.
+
+Scenario:
+- actual version is `v3.23.291`
+- tag one of the commit on your branch with the new version you want.
+  - it is **important** that the patch version be `-1`, since it will be incremented automatically by _Travis CI_.
+  - `git tag v3.24.-1 && git push --tags`
+- open the pull request.
+- after merge, _Travis CI_ will tag automatically the right final version `v3.24.0`.
+- delete the temporary manual tag
+  - `git tag -d v3.24.-1 && git push --tags`
+
+### Increment the major version
+Since _Travis CI_ only automatically increases the patch-version, we need to manually pre-tag with the new version we
+want.
+
+Scenario:
+- actual version is `v3.23.291`
+- tag one of the commit on your branch with the new version you want.
+  - it is **important** that the patch version be `-1`, since it will be incremented automatically by _Travis CI_.
+  - `git tag v4.0.-1 && git push --tags`
+- open the pull request.
+- after merge, _Travis CI_ will tag automatically the right final version `v4.0.0`.
+- delete the temporary manual tag
+  - `git tag -d v4.0.-1 && git push --tags`
 
 
 ## License


### PR DESCRIPTION
See updated README.md for information on this way.

It is no longer using the commit message (found bugs in this approach, _Skipper_ is doing it wrong).